### PR TITLE
feat: add 'autoPlay' option for better usage experience

### DIFF
--- a/src/components/AudioPlayer.vue
+++ b/src/components/AudioPlayer.vue
@@ -84,6 +84,7 @@ const mergeOption = (option: AudioPlayerOption): AudioPlayerOption => {
   return {
     src: option.src || AudioPlayerOptionDefault.src,
     title: option.title || AudioPlayerOptionDefault.title,
+    autoPlay: option.autoPlay || AudioPlayerOptionDefault.autoPlay,
     coverImage: option.coverImage || AudioPlayerOptionDefault.coverImage,
     coverRotate: option.coverRotate || AudioPlayerOptionDefault.coverRotate,
     progressBarColor:
@@ -119,7 +120,7 @@ export default defineComponent({
     const audioProgressPoint = ref()
     const audioProgress = ref()
     const progressInterval = 200
-    const option_ = ref(mergeOption(props.option))
+    const option_ = ref<AudioPlayerOption>(mergeOption(props.option))
     let toucher: any = null
     let timer: any = null
     const state = reactive({
@@ -129,6 +130,15 @@ export default defineComponent({
       totalTime: 0,
       totalTimeStr: '00:00',
     })
+
+    //tips: initialize the state when switch music.
+    const initState = () => {
+      state.isPlaying = false
+      state.isDragging = false
+      state.currentTime = 0
+      state.totalTime = 0
+      state.totalTimeStr = '00:00'
+    }
 
     const playUpdate = () => {
       if (state.isDragging) {
@@ -252,9 +262,13 @@ export default defineComponent({
       () => props.option,
       (newValue, oldValue) => {
         option_.value = mergeOption(newValue)
-        nextTick(() => {
-          play()
-        })
+        initState()
+        console.log('option_.value', option_.value)
+        if (option_.value.autoPlay) {
+          nextTick(() => {
+            play()
+          })
+        }
       },
       { deep: true },
     )

--- a/src/components/AudioPlayer.vue
+++ b/src/components/AudioPlayer.vue
@@ -263,7 +263,6 @@ export default defineComponent({
       (newValue, oldValue) => {
         option_.value = mergeOption(newValue)
         initState()
-        console.log('option_.value', option_.value)
         if (option_.value.autoPlay) {
           nextTick(() => {
             play()

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,6 +1,7 @@
 export interface AudioPlayerOption {
   src: string //audio source
   title?: string //audio title
+  autoPlay?: boolean
   coverImage?: string //cover image
   coverRotate?: boolean //cover rotate when playing
   progressBarColor?: string //progress bar color
@@ -10,6 +11,7 @@ export interface AudioPlayerOption {
 export const AudioPlayerOptionDefault: AudioPlayerOption = {
   src: '',
   title: '',
+  autoPlay: false,
   coverImage: '',
   coverRotate: true,
   progressBarColor: '#3C91F4',


### PR DESCRIPTION
Hello 👋, I have used vue3-audio-player in my project, but I find a terrible issue (someone has opened #3 ) in the use. And I fix this issue. 

I added a prop named "autoPlay", to control the audio player. So that makes it will not auto-play the music when the user switch music.